### PR TITLE
update copyright to refer to OpenJS Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,5 +118,5 @@ npm run publish remote=
 The Intern version badges were generated at https://shields.io with
 https://img.shields.io/badge/intern-v4-green.svg?colorB=2EC186.
 
-© [SitePen, Inc.](http://sitepen.com) and its
-[contributors](https://github.com/theintern/theintern.github.io/graphs/contributors)
+© [OpenJS Foundation](https://openjsf.org/) and its
+[contributors](https://github.com/theintern/intern/graphs/contributors)

--- a/assets/README.md
+++ b/assets/README.md
@@ -4,4 +4,4 @@
 
 Jump over to the [source branch](https://github.com/theintern/theintern.github.io/tree/source) to see the site source as well as build instructions and contribution guidelines.
 
-© [SitePen, Inc.](http://sitepen.com) and its [contributors](https://github.com/theintern/theintern.github.io/graphs/contributors)
+© [OpenJS Foundation](https://openjsf.org/) and its [contributors](https://github.com/theintern/intern/graphs/contributors)

--- a/site/layouts/partials/footer.ejs
+++ b/site/layouts/partials/footer.ejs
@@ -10,11 +10,11 @@
 
 				<div class="level-item">
 					<span class="copyright">
-						&copy; 2017 <a href="https://www.sitepen.com">SitePen, Inc.</a>
+						&copy; <%= new Date().getFullYear() %> <a href="https://openjsf.org/">OpenJS Foundation</a>
 					</span>
 				</div>
 				<div class="level-item">
-					<span>Intern is a <a href="http://js.foundation">JS Foundation</a> project.</span>
+					<span>Intern is created by <a href="https://www.sitepen.com/">SitePen</a>.</span>
 				</div>
 				<div class="level-item">
 					<span><a href="https://github.com/theintern/intern/blob/master/LICENSE">New BSD</a> licensed.</span>


### PR DESCRIPTION
Changes the SitePen copyright to OpenJS Foundation copyright in READMEs and in site footer. Still retains a reference to SitePen in the footer. Also updates copyright year with each new build.

closes #16

### Updated footer:
![Screen Shot of webpage footer](https://user-images.githubusercontent.com/11273838/72471313-4676c680-3797-11ea-9146-f3e3f1d347cd.png)

